### PR TITLE
Fixed that non ascii characters don't map to single byte

### DIFF
--- a/distance/damerau_levenshtein.go
+++ b/distance/damerau_levenshtein.go
@@ -13,25 +13,27 @@ func DamerauLevenshteinDistance(s1, s2 string) float64 {
 		return 0
 	}
 
+	r1, r2 := []rune(s1), []rune(s2) // Use runes to solve problem with non ascii characters counting as 2 or more bytes
+
 	// Create the matrix matrix
-	matrix := make([][]int32, len(s1)+1)
+	matrix := make([][]int32, len(r1)+1)
 	for i := range matrix {
-		matrix[i] = make([]int32, len(s2)+1)
+		matrix[i] = make([]int32, len(r2)+1)
 	}
 
 	// Set prefixes AKA setting the edges
-	for i := range max(len(s1), len(s2)) + 1 {
-		if len(s1) >= i {
+	for i := range max(len(r1), len(r2)) + 1 {
+		if len(r1) >= i {
 			matrix[i][0] = int32(i)
 		}
-		if len(s2) >= i {
+		if len(r2) >= i {
 			matrix[0][i] = int32(i)
 		}
 	}
 
 	// Fill the matrix
-	for j, jr := range s2 {
-		for i, ir := range s1 {
+	for j, jr := range r2 {
+		for i, ir := range r1 {
 			var subCost int32 = 1
 			if jr == ir {
 				subCost = 0
@@ -42,12 +44,12 @@ func DamerauLevenshteinDistance(s1, s2 string) float64 {
 				matrix[i+1][j]+1,
 				matrix[i][j]+subCost)
 
-			if i >= 1 && j >= 1 && s1[i] == s2[j-1] && s1[i-1] == s2[j] {
+			if i >= 1 && j >= 1 && r1[i] == r2[j-1] && r1[i-1] == r2[j] {
 				matrix[i+1][j+1] = min(matrix[i+1][j+1], matrix[i-1][j-1]+1)
 			}
 		}
 	}
 
 	// Return the distance
-	return float64(matrix[len(s1)][len(s2)])
+	return float64(matrix[len(r1)][len(r2)])
 }

--- a/distance/damerau_levenshtein_test.go
+++ b/distance/damerau_levenshtein_test.go
@@ -79,3 +79,11 @@ func TestDamerauLevenshteinRepeating(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestDamerauLevenshteinNonAscii(t *testing.T) {
+	dist := distance.DamerauLevenshteinDistance("båt", "bat")
+	t.Logf("Expected 1 got %f\n", dist)
+	if dist != 1 {
+		t.FailNow()
+	}
+}

--- a/distance/levenshtein.go
+++ b/distance/levenshtein.go
@@ -12,25 +12,27 @@ func LevenshteinDistance(s1, s2 string) float64 {
 		return 0
 	}
 
+	r1, r2 := []rune(s1), []rune(s2) // Use runes to solve problem with non ascii characters counting as 2 or more bytes
+
 	// Create the matrix matrix
-	matrix := make([][]int32, len(s1)+1)
+	matrix := make([][]int32, len(r1)+1)
 	for i := range matrix {
-		matrix[i] = make([]int32, len(s2)+1)
+		matrix[i] = make([]int32, len(r2)+1)
 	}
 
 	// Set prefixes AKA setting the edges
-	for i := range max(len(s1), len(s2)) + 1 {
-		if len(s1) >= i {
+	for i := range max(len(r1), len(r2)) + 1 {
+		if len(r1) >= i {
 			matrix[i][0] = int32(i)
 		}
-		if len(s2) >= i {
+		if len(r2) >= i {
 			matrix[0][i] = int32(i)
 		}
 	}
 
 	// Fill the matrix
-	for j, jr := range s2 {
-		for i, ir := range s1 {
+	for j, jr := range r2 {
+		for i, ir := range r1 {
 			var subCost int32 = 1
 			if jr == ir {
 				subCost = 0
@@ -44,5 +46,5 @@ func LevenshteinDistance(s1, s2 string) float64 {
 	}
 
 	// Return the distance
-	return float64(matrix[len(s1)][len(s2)])
+	return float64(matrix[len(r1)][len(r2)])
 }

--- a/distance/levenshtein_test.go
+++ b/distance/levenshtein_test.go
@@ -47,3 +47,11 @@ func TestLevenshteinRepeating(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestLevenshteinNonAscii(t *testing.T) {
+	dist := distance.LevenshteinDistance("båt", "bat")
+	t.Logf("Expected 1 got %f\n", dist)
+	if dist != 1 {
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
The distance algorithms were using byte arrays to map calculate the distance, but strings in golang uses utf8 which does not map nicely to a byte array, but this is now fixed by using runes instead of bytes